### PR TITLE
Fixed field verification issue

### DIFF
--- a/Frontend/src/views/PointEditor.vue
+++ b/Frontend/src/views/PointEditor.vue
@@ -191,11 +191,16 @@ export default {
       //  this prevents an error caused when updating the marker location
       if(this.point.latitude == "" || this.point.longitude == "" || 
           this.point.latitude < -90 || this.point.latitude > 90 ||
-          this.point.longitude < -180 || this.point.longitude > 180) {
+          this.point.longitude < -180 || this.point.longitude > 180 ||
+          Number.isNaN(Number.parseFloat(this.point.latitude)) ||
+          Number.isNaN(Number.parseFloat(this.point.longitude))) {
 
         //determines error type and corresponding display message
         if(this.point.latitude == "" || this.point.longitude == "") {
           this.error = "Latitude/longitude value cannot be empty.";
+        } else if(Number.isNaN(Number.parseFloat(this.point.latitude)) ||
+          Number.isNaN(Number.parseFloat(this.point.longitude))) {
+          this.error = "Latitude/longitude value must be a number."
         } else {
           this.error = "Latitude/Longitude value invalid."
         }


### PR DESCRIPTION
# Description

Latitude longitude fields in point editor were not checked to ensure a float value was entered. Now they are checked.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Localhost test.
